### PR TITLE
fix: warn when conf.level is passed inside estimation call

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# metasurvey 0.0.23
+
+## Bug fixes
+* `workflow()` now warns when `conf.level` is passed inside an estimation call
+  (e.g., `svymean(~x, conf.level = 0.9)`) where it is silently ignored. The
+  warning guides the user to pass `conf.level` to `workflow()` instead.
+
 # metasurvey 0.0.22
 
 ## New features

--- a/R/workflow.R
+++ b/R/workflow.R
@@ -123,6 +123,7 @@ workflow <- function(svy, ..., estimation_type = "monthly",
 workflow_default <- function(survey, ..., estimation_type = "monthly",
                              conf.level = 0.95) {
   .calls <- substitute(list(...))
+  .warn_conf_level_in_calls(.calls)
 
   result <- rbindlist(
     lapply(
@@ -210,6 +211,7 @@ workflow_pool <- function(survey, ..., estimation_type = "monthly",
   }
 
   .calls <- substitute(list(...))
+  .warn_conf_level_in_calls(.calls)
 
   if (all(c("rho", "R") %in% names(.calls))) {
     rho <- eval(.calls[["rho"]])
@@ -306,6 +308,21 @@ workflow_pool <- function(survey, ..., estimation_type = "monthly",
   return(out)
 }
 
+
+.warn_conf_level_in_calls <- function(.calls) {
+  for (i in seq.int(2L, length(.calls))) {
+    call_args <- as.list(.calls[[i]])
+    if ("conf.level" %in% names(call_args)) {
+      fn_name <- deparse(call_args[[1]])
+      warning(
+        "'conf.level' was passed inside ", fn_name, "() where it is ignored. ",
+        "Pass it to workflow() instead:\n",
+        "  workflow(..., conf.level = ", deparse(call_args[["conf.level"]]), ")",
+        call. = FALSE
+      )
+    }
+  }
+}
 
 cat_estimation <- function(estimation, call, conf.level = 0.95) {
   class_estimation <- class(estimation)[1]

--- a/tests/testthat/test-workflow.R
+++ b/tests/testthat/test-workflow.R
@@ -526,3 +526,42 @@ test_that("workflow works with convey functions", {
   expect_true(nrow(result) == 1)
   expect_true(result$value > 0 && result$value < 1)
 })
+
+# ── conf.level tests ─────────────────────────────────────────────────────────
+
+test_that("conf.level changes confidence intervals", {
+  svy <- make_test_survey(100)
+
+  r95 <- workflow(list(svy), survey::svymean(~x, na.rm = TRUE),
+    estimation_type = "annual"
+  )
+  r90 <- workflow(list(svy), survey::svymean(~x, na.rm = TRUE),
+    estimation_type = "annual", conf.level = 0.90
+  )
+
+  expect_equal(r95$value, r90$value)
+  expect_true(r90$confint_lower > r95$confint_lower)
+  expect_true(r90$confint_upper < r95$confint_upper)
+})
+
+test_that("conf.level inside estimation call warns", {
+  svy <- make_test_survey(50)
+
+  expect_warning(
+    workflow(list(svy),
+      survey::svymean(~x, na.rm = TRUE, conf.level = 0.8),
+      estimation_type = "annual"
+    ),
+    "conf.level.*inside.*svymean.*Pass it to workflow"
+  )
+
+  expect_warning(
+    workflow(list(svy),
+      survey::svyby(~x, ~region, survey::svymean,
+        na.rm = TRUE, conf.level = 0.8
+      ),
+      estimation_type = "annual"
+    ),
+    "conf.level.*inside.*svyby.*Pass it to workflow"
+  )
+})


### PR DESCRIPTION
## Summary
- `conf.level` passed inside `svymean()`/`svyby()`/`svytotal()` is silently ignored, causing users to get 95% intervals regardless of the value they set
- Added `.warn_conf_level_in_calls()` that inspects substituted calls and emits a warning guiding the user to pass `conf.level` to `workflow()` instead

## Test plan
- [x] `conf.level` effectively changes intervals when passed to `workflow()`
- [x] Warning emitted when `conf.level` inside `svymean()`
- [x] Warning emitted when `conf.level` inside `svyby()`
- [x] No warning when `conf.level` passed correctly to `workflow()`
- [x] All 88 workflow tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)