### PR TITLE
feat: support conf.level inside estimation calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,10 @@
 # metasurvey 0.0.23
 
-## Bug fixes
-* `workflow()` now warns when `conf.level` is passed inside an estimation call
-  (e.g., `svymean(~x, conf.level = 0.9)`) where it is silently ignored. The
-  warning guides the user to pass `conf.level` to `workflow()` instead.
+## New features
+* `workflow()` now supports `conf.level` inside individual estimation calls
+  (e.g., `svymean(~x, na.rm = TRUE, conf.level = 0.80)`). The per-call value
+  overrides the `workflow()` default, allowing different confidence levels for
+  each estimation in the same call.
 
 # metasurvey 0.0.22
 

--- a/R/workflow.R
+++ b/R/workflow.R
@@ -16,6 +16,9 @@
 #'   with multiple types
 #' @param conf.level Confidence level for the interval (default `0.95`).
 #'   Passed to \code{\link[stats]{confint}}.
+#'   Can also be set per-call inside the estimation function
+#'   (e.g., `svymean(~x, na.rm = TRUE, conf.level = 0.90)`),
+#'   which overrides the `workflow()` default for that estimation.
 #'
 #' @return \code{data.table} with results from all
 #'   estimations, including columns:
@@ -73,12 +76,19 @@
 #'   estimation_type = "annual"
 #' )
 #'
-#' # Custom confidence level (90%)
+#' # Custom confidence level (90%) for all estimations
 #' result_90 <- workflow(
 #'   svy = list(svy),
 #'   survey::svymean(~x, na.rm = TRUE),
 #'   estimation_type = "annual",
 #'   conf.level = 0.90
+#' )
+#'
+#' # Per-call confidence level (overrides workflow default)
+#' result_mixed <- workflow(
+#'   svy = list(svy),
+#'   survey::svymean(~x, na.rm = TRUE, conf.level = 0.80),
+#'   estimation_type = "annual"
 #' )
 #'
 #' @seealso
@@ -123,7 +133,6 @@ workflow <- function(svy, ..., estimation_type = "monthly",
 workflow_default <- function(survey, ..., estimation_type = "monthly",
                              conf.level = 0.95) {
   .calls <- substitute(list(...))
-  .warn_conf_level_in_calls(.calls)
 
   result <- rbindlist(
     lapply(
@@ -143,6 +152,8 @@ workflow_default <- function(survey, ..., estimation_type = "monthly",
                   function(i) {
                     call <- as.list(.calls[[i]])
                     name_function <- deparse(call[[1]])
+                    extracted <- .extract_conf_level(call, conf.level)
+                    call <- as.list(extracted$call)
                     call[["design"]] <- substitute(design)
                     call <- as.call(call)
                     estimation <- eval(
@@ -152,7 +163,7 @@ workflow_default <- function(survey, ..., estimation_type = "monthly",
 
                     return(cat_estimation(
                       estimation, name_function,
-                      conf.level = conf.level
+                      conf.level = extracted$conf.level
                     ))
                   }
                 ),
@@ -211,7 +222,6 @@ workflow_pool <- function(survey, ..., estimation_type = "monthly",
   }
 
   .calls <- substitute(list(...))
-  .warn_conf_level_in_calls(.calls)
 
   if (all(c("rho", "R") %in% names(.calls))) {
     rho <- eval(.calls[["rho"]])
@@ -243,6 +253,8 @@ workflow_pool <- function(survey, ..., estimation_type = "monthly",
                   function(j) {
                     call <- as.list(.calls[[j]])
                     name_function <- deparse(call[[1]])
+                    extracted <- .extract_conf_level(call, conf.level)
+                    call <- as.list(extracted$call)
                     call[["design"]] <- substitute(design)
                     call <- as.call(call)
                     estimation <- eval(
@@ -253,7 +265,7 @@ workflow_pool <- function(survey, ..., estimation_type = "monthly",
                     )
                     return(cat_estimation(
                       estimation, name_function,
-                      conf.level = conf.level
+                      conf.level = extracted$conf.level
                     ))
                   }
                 )
@@ -309,18 +321,13 @@ workflow_pool <- function(survey, ..., estimation_type = "monthly",
 }
 
 
-.warn_conf_level_in_calls <- function(.calls) {
-  for (i in seq.int(2L, length(.calls))) {
-    call_args <- as.list(.calls[[i]])
-    if ("conf.level" %in% names(call_args)) {
-      fn_name <- deparse(call_args[[1]])
-      warning(
-        "'conf.level' was passed inside ", fn_name, "() where it is ignored. ",
-        "Pass it to workflow() instead:\n",
-        "  workflow(..., conf.level = ", deparse(call_args[["conf.level"]]), ")",
-        call. = FALSE
-      )
-    }
+.extract_conf_level <- function(call_args, default) {
+  if ("conf.level" %in% names(call_args)) {
+    cl <- eval(call_args[["conf.level"]])
+    call_args[["conf.level"]] <- NULL
+    list(conf.level = cl, call = as.call(call_args))
+  } else {
+    list(conf.level = default, call = as.call(call_args))
   }
 }
 

--- a/man/workflow.Rd
+++ b/man/workflow.Rd
@@ -21,7 +21,10 @@ determines which weight to use. Options:
 with multiple types}
 
 \item{conf.level}{Confidence level for the interval (default \code{0.95}).
-Passed to \code{\link[stats]{confint}}.}
+Passed to \code{\link[stats]{confint}}.
+Can also be set per-call inside the estimation function
+(e.g., \code{svymean(~x, na.rm = TRUE, conf.level = 0.90)}),
+which overrides the \code{workflow()} default for that estimation.}
 }
 \value{
 \code{data.table} with results from all
@@ -85,12 +88,19 @@ result_by <- workflow(
   estimation_type = "annual"
 )
 
-# Custom confidence level (90\%)
+# Custom confidence level (90\%) for all estimations
 result_90 <- workflow(
   svy = list(svy),
   survey::svymean(~x, na.rm = TRUE),
   estimation_type = "annual",
   conf.level = 0.90
+)
+
+# Per-call confidence level (overrides workflow default)
+result_mixed <- workflow(
+  svy = list(svy),
+  survey::svymean(~x, na.rm = TRUE, conf.level = 0.80),
+  estimation_type = "annual"
 )
 
 }

--- a/tests/testthat/test-workflow.R
+++ b/tests/testthat/test-workflow.R
@@ -544,24 +544,54 @@ test_that("conf.level changes confidence intervals", {
   expect_true(r90$confint_upper < r95$confint_upper)
 })
 
-test_that("conf.level inside estimation call warns", {
-  svy <- make_test_survey(50)
+test_that("conf.level inside estimation call is used", {
+  svy <- make_test_survey(100)
 
-  expect_warning(
-    workflow(list(svy),
-      survey::svymean(~x, na.rm = TRUE, conf.level = 0.8),
-      estimation_type = "annual"
-    ),
-    "conf.level.*inside.*svymean.*Pass it to workflow"
+  r95 <- workflow(list(svy), survey::svymean(~x, na.rm = TRUE),
+    estimation_type = "annual"
+  )
+  r80 <- workflow(list(svy),
+    survey::svymean(~x, na.rm = TRUE, conf.level = 0.80),
+    estimation_type = "annual"
   )
 
-  expect_warning(
-    workflow(list(svy),
-      survey::svyby(~x, ~region, survey::svymean,
-        na.rm = TRUE, conf.level = 0.8
-      ),
-      estimation_type = "annual"
-    ),
-    "conf.level.*inside.*svyby.*Pass it to workflow"
+  expect_equal(r95$value, r80$value)
+  expect_true(r80$confint_lower > r95$confint_lower)
+  expect_true(r80$confint_upper < r95$confint_upper)
+})
+
+test_that("conf.level inside svyby call is used", {
+  svy <- make_test_survey(100)
+
+  r95 <- workflow(list(svy),
+    survey::svyby(~x, ~region, survey::svymean, na.rm = TRUE),
+    estimation_type = "annual"
   )
+  r80 <- workflow(list(svy),
+    survey::svyby(~x, ~region, survey::svymean,
+      na.rm = TRUE,
+      conf.level = 0.80
+    ),
+    estimation_type = "annual"
+  )
+
+  expect_equal(r95$value, r80$value)
+  expect_true(all(r80$confint_lower > r95$confint_lower))
+  expect_true(all(r80$confint_upper < r95$confint_upper))
+})
+
+test_that("per-call conf.level overrides workflow default", {
+  svy <- make_test_survey(100)
+
+  result <- workflow(list(svy),
+    survey::svymean(~x, na.rm = TRUE, conf.level = 0.80),
+    estimation_type = "annual", conf.level = 0.99
+  )
+  r80 <- workflow(list(svy),
+    survey::svymean(~x, na.rm = TRUE),
+    estimation_type = "annual", conf.level = 0.80
+  )
+
+  expect_equal(result$confint_lower, r80$confint_lower)
+  expect_equal(result$confint_upper, r80$confint_upper)
 })


### PR DESCRIPTION
## Summary
- `conf.level` can now be passed inside `svymean()`/`svyby()`/`svytotal()` calls within `workflow()` and it will be used for that estimation's confidence intervals
- Per-call `conf.level` overrides the `workflow()` default, allowing different confidence levels for each estimation
- The value is extracted from the call before evaluation (since `svymean`/`svytotal` don't accept it) and forwarded to `stats::confint()`

## Test plan
- [x] `conf.level` inside `svymean()` changes intervals
- [x] `conf.level` inside `svyby()` changes intervals
- [x] Per-call `conf.level` overrides `workflow()` default
- [x] Default `conf.level` from `workflow()` still works when not set per-call
- [x] All 94 workflow tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)